### PR TITLE
bugfix - padding to margin & media

### DIFF
--- a/src/sass/components/_gallery.scss
+++ b/src/sass/components/_gallery.scss
@@ -3,8 +3,7 @@
     justify-content: center;
     width: 100vw;
     padding-inline: 0;
-    padding-bottom: 80px;
-    margin: 0;
+    margin-bottom: 80px;
     height: auto;
     background-image: linear-gradient(
         to bottom,
@@ -18,4 +17,10 @@
     width: 100%;
     height: auto;
     object-fit: cover;
+}
+
+@media screen and (min-width: 768px ) {
+   .gallery{
+    margin-bottom: 120px;
+   }
 }


### PR DESCRIPTION
.gallery - Zmiana padding-bottom na margin-bottom. Padding powodował rozjazd między zdjęciem, a tłem. Szczegółowe info na Trello.
dodałem media - (min-width: 768px) przegapiłem, że od tablet zwiększa się odstęp od sekcji niżej.